### PR TITLE
BUG-834: Fix copying to freetext author property on create

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.author changes
 2.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BUG-834: Fix copying to freetext author property on create
 
 
 2.8.0 (2017-10-04)

--- a/src/zeit/content/author/author.py
+++ b/src/zeit/content/author/author.py
@@ -132,8 +132,6 @@ def update_freetext_on_change(context, event):
     zeit.cms.content.interfaces.ICommonMetadata,
     zope.lifecycleevent.interfaces.IObjectCreatedEvent)
 def update_freetext_on_add(context, event):
-    if not zeit.cms.checkout.interfaces.ILocalContent.providedBy(context):
-        return
     update_author_freetext(context)
 
 


### PR DESCRIPTION
Reformulate tests to use actual content object mechanics instead of
mocking everything, since that didn't tell us anything helpful.

I don't really know what I was thinking to expect ILocalContent on
ObjectCreated, since the form sends that _before_ adding to the
repository and checking out for the first time...