### PR TITLE
ZON-5047: Add occupation field

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.content.author changes
 2.9.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ZON-5047: Add occupation text field
 
 
 2.9.6 (2019-01-25)

--- a/src/zeit/content/author/author.py
+++ b/src/zeit/content/author/author.py
@@ -44,6 +44,7 @@ class Author(zeit.cms.content.xmlsupport.XMLContentBase):
         'firstname',
         'instagram',
         'lastname',
+        'occupation',
         'status',
         'summary',
         'title',

--- a/src/zeit/content/author/interfaces.py
+++ b/src/zeit/content/author/interfaces.py
@@ -102,6 +102,12 @@ class IAuthor(zope.interface.Interface,
         value_type=zope.schema.Choice(
             source=zeit.cms.related.interfaces.relatableContentSource))
 
+    occupation = zope.schema.TextLine(
+        title=_('Occupation'),
+        max_length=16,
+        required=False
+    )
+
     topiclink_label_1 = zope.schema.TextLine(
         title=_('Label for favourite topic #1'),
         required=False)


### PR DESCRIPTION
Übersetzungen sind auf dem master, aber noch nicht released.
[Ticket](https://zeit-online.atlassian.net/browse/ZON-5047) ist das hier und man beachte den Kommentar.
